### PR TITLE
fix: exception statement syntax

### DIFF
--- a/library/okta_apps.py
+++ b/library/okta_apps.py
@@ -330,7 +330,7 @@ def main():
 
     try:
         js = json.loads(content)
-    except ValueError, e:
+    except ValueError:
         js = ""
 
     uresp['json'] = js

--- a/library/okta_apps_saml.py
+++ b/library/okta_apps_saml.py
@@ -375,7 +375,7 @@ def main():
 
     try:
         js = json.loads(content)
-    except ValueError, e:
+    except ValueError:
         js = ""
 
     uresp['json'] = js

--- a/library/okta_apps_swa.py
+++ b/library/okta_apps_swa.py
@@ -275,7 +275,7 @@ def main():
 
     try:
         js = json.loads(content)
-    except ValueError, e:
+    except ValueError:
         js = ""
 
     uresp['json'] = js

--- a/library/okta_groups.py
+++ b/library/okta_groups.py
@@ -298,7 +298,7 @@ def main():
 
     try:
         js = json.loads(content)
-    except ValueError, e:
+    except ValueError:
         js = ""
 
     uresp['json'] = js

--- a/library/okta_users.py
+++ b/library/okta_users.py
@@ -378,7 +378,7 @@ def main():
 
     try:
         js = json.loads(content)
-    except ValueError, e:
+    except ValueError:
         js = ""
 
     uresp['json'] = js


### PR DESCRIPTION
Wrong exception statement is used here:
```
$ ansible-doc -vvvv okta_groups
ansible-doc 2.9.2
  config file = None
  configured module search path = ['***']
  ansible python module location = /Users/foo/venv/ansible/lib/python3.7/site-packages/ansible
  executable location = /Users/foo/venv/ansible/bin/ansible-doc
  python version = 3.7.5 (default, Nov  1 2019, 02:16:32) [Clang 11.0.0 (clang-1100.0.33.8)]
No config file found; using defaults
 [ERROR]: unable to parse ***/library/okta_groups.py

Traceback (most recent call last):
  File "/Users/foo/venv/ansible/lib/python3.7/site-packages/ansible/cli/doc.py", line 195, in run
    doc, plainexamples, returndocs, metadata = DocCLI._get_plugin_doc(plugin, loader, search_paths)
  File "/Users/foo/venv/ansible/lib/python3.7/site-packages/ansible/cli/doc.py", line 302, in _get_plugin_doc
    doc, plainexamples, returndocs, metadata = get_docstring(filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0))
  File "/Users/foo/venv/ansible/lib/python3.7/site-packages/ansible/utils/plugin_docs.py", line 124, in get_docstring
    data = read_docstring(filename, verbose=verbose, ignore_errors=ignore_errors)
  File "/Users/foo/venv/ansible/lib/python3.7/site-packages/ansible/parsing/plugin_docs.py", line 40, in read_docstring
    M = ast.parse(b_module_data.read())
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 301
    except ValueError, e:
                     ^
SyntaxError: invalid syntax

ERROR! module okta_groups missing documentation (or could not parse documentation): invalid syntax (<unknown>, line 301)
```